### PR TITLE
Add JSON support in extra_vars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,7 +3,7 @@
 ## v0.5.0
 
 * Added ability to use yaml structures to pass arbitrarily complex values through extra_vars. key=value and @file syntax is still supported. Example usage:
-```
+```yaml
 sample_task:
   action: ansible.playbook
   input:
@@ -26,7 +26,7 @@ sample_task:
 ## v0.4
 
 * Breaking Change: Added ability to pass in multiple extra_vars. The extra_vars parameter is now a list. Example usage:
-```
+```yaml
 sample_task:
   action: ansible.playbook
   input:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.5.0
+
+* Added ability to use yaml structures to pass arbitrarily complex values through extra_vars. key=value and @file syntax is still supported. Example usage:
+```
+sample_task:
+  action: ansible.playbook
+  input:
+    playbook: playbook.yml
+    extra_vars:
+      - key1=value1
+      -
+        key2: value2
+        key3: [ value3a, value3b ]
+        key4:
+          - value4a
+          - { value4bkey: value4bvalue }
+        key5:
+          key6: value6
+          key7: value7
+      - @path/to/file.yml
+        ...
+```
+
 ## v0.4
 
 * Breaking Change: Added ability to pass in multiple extra_vars. The extra_vars parameter is now a list. Example usage:

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ sample_task:
       - key2=value2
       #
       # variables from a yaml (or json) file
-      - @/path/to/file.yml
+      - '@/path/to/file.yml'
       #
 	  # an arbitrarily complex dict of variables (passed as JSON to ansible)
       -

--- a/README.md
+++ b/README.md
@@ -40,6 +40,36 @@ st2 run ansible.playbook playbook=/etc/ansible/playbooks/nginx.yml
 # run playbook on last machine listed in inventory file
 st2 run ansible.playbook playbook=/etc/ansible/playbooks/nginx.yml limit='all[-1]'
 ```
+
+This is an example from a workflow that passes several several different
+variables to the playbook as extra-vars:
+
+```yaml
+sample_task:
+  action: ansible.playbook
+  input:
+    playbook: /path/to/playbook.yml
+    extra_vars:
+      #
+      # as key=value pairs
+      - key1=value1
+      - key2=value2
+      #
+      # variables from a yaml (or json) file
+      - @/path/to/file.yml
+      #
+	  # an arbitrarily complex dict of variables (passed as JSON to ansible)
+      -
+        key3: "{{ value3 }}"
+        key4: [ value4a, value4b ]
+        key5:
+          - value5a
+          - { value5bkey: value5bvalue }
+        key6:
+          key7: value7
+          key8: value8
+```
+
 ##### Structured output
 ```sh
 # get structured JSON output from a playbook

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ sample_task:
       # variables from a yaml (or json) file
       - '@/path/to/file.yml'
       #
-	  # an arbitrarily complex dict of variables (passed as JSON to ansible)
+      # an arbitrarily complex dict of variables (passed as JSON to ansible)
       -
         key3: "{{ value3 }}"
         key4: [ value4a, value4b ]

--- a/actions/command.yaml
+++ b/actions/command.yaml
@@ -53,7 +53,7 @@ parameters:
     description: "Connection type to use (default=smart) [-c]"
     type: string
   extra_vars:
-    description: "List of additional variables to pass to ansible. Each variable is represented as \"key=value\" or \"@path/to/file.yaml|json\" or use a yaml dict (\"key: [1, 2, 3]\") to send JSON. [-e]"
+    description: 'List of additional variables to pass to ansible. Each variable is represented as "key=value" or "@path/to/file.yaml|json" or use a yaml dict ("key: [1, 2, 3]") to send JSON. [-e]'
     type: array
   forks:
     description: "Specify number of parallel processes to use (default=5) [-f]"

--- a/actions/command.yaml
+++ b/actions/command.yaml
@@ -53,7 +53,7 @@ parameters:
     description: "Connection type to use (default=smart) [-c]"
     type: string
   extra_vars:
-    description: "List of additional variables to pass to ansible. Each variable is represented as \"key=value\" or \"@path/to/file.yaml|json\" [-e]."
+    description: "List of additional variables to pass to ansible. Each variable is represented as \"key=value\" or \"@path/to/file.yaml|json\" or use a yaml dict (\"key: [1, 2, 3]\") to send JSON. [-e]"
     type: array
   forks:
     description: "Specify number of parallel processes to use (default=5) [-f]"

--- a/actions/command_local.yaml
+++ b/actions/command_local.yaml
@@ -57,7 +57,7 @@ parameters:
     default: local
     immutable: true
   extra_vars:
-    description: "List of additional variables to pass to ansible. Each variable is represented as \"key=value\" or \"@path/to/file.yaml|json\" or use a yaml dict (\"key: [1, 2, 3]\") to send JSON. [-e]"
+    description: 'List of additional variables to pass to ansible. Each variable is represented as "key=value" or "@path/to/file.yaml|json" or use a yaml dict ("key: [1, 2, 3]") to send JSON. [-e]'
     type: array
   forks:
     description: "Specify number of parallel processes to use (default=5) [-f]"

--- a/actions/command_local.yaml
+++ b/actions/command_local.yaml
@@ -57,7 +57,7 @@ parameters:
     default: local
     immutable: true
   extra_vars:
-    description: "List of additional variables to pass to ansible. Each variable is represented as \"key=value\" or \"@path/to/file.yaml|json\" [-e]."
+    description: "List of additional variables to pass to ansible. Each variable is represented as \"key=value\" or \"@path/to/file.yaml|json\" or use a yaml dict (\"key: [1, 2, 3]\") to send JSON. [-e]"
     type: array
   forks:
     description: "Specify number of parallel processes to use (default=5) [-f]"

--- a/actions/lib/ansible_base.py
+++ b/actions/lib/ansible_base.py
@@ -45,10 +45,9 @@ class AnsibleBaseRunner(object):
         for i, arg in enumerate(self.args):
             if '--extra_vars' in arg:
                 var_list_str = arg.split("--extra_vars=")[1]
-                var_list_str = arg.split("--extra_vars=")[1]
                 var_list = []
                 for n in ast.literal_eval(var_list_str):
-                    if type(n) in six.string_types:
+                    if isinstance(n, six.string_types):
                         if n.strip().startswith("@"):
                             var_list.append(('file', n.strip()))
                         else:
@@ -57,6 +56,7 @@ class AnsibleBaseRunner(object):
                         var_list.append(('json', n))
 
                 last = ''
+                kv_param = ''
                 for t, v in var_list:
                     # Add --extra-vars for each file
                     if t == 'file':
@@ -77,6 +77,9 @@ class AnsibleBaseRunner(object):
                         kv_param = ""
 
                     last = t
+
+                if kv_param:
+                    self.args.append(kv_param)
 
                 del self.args[i]  # Delete the original arg since we split it into separate ones
                 break

--- a/actions/lib/ansible_base.py
+++ b/actions/lib/ansible_base.py
@@ -3,6 +3,8 @@ import sys
 import subprocess
 import shell
 import ast
+import json
+import six
 
 __all__ = [
     'AnsibleBaseRunner'
@@ -30,35 +32,51 @@ class AnsibleBaseRunner(object):
         This method turns the string list ("--extra_vars=[...]") passed in from the args
         into an actual list and adds new --extra-vars kwargs for file and k\v entries.
 
-        Example:
+        Example (line breaks added for readability):
           Input from args:
-            "--extra_vars=[u'"@path/to/vars_file.yml"', u'"key1=value1", u'"key2=value2"']"
+            "--extra_vars=[u'"@path/to/vars_file.yml"',
+                           u'"key1=value1", u'"key2=value2"',
+                           {u'"key3"': u'"value3"'}]"
           Passed to Ansible after transformation:
-            ... --extra-vars=@path/to/vars_file.yml --extra-vars=key1=value1 key2=value2 ...
+            ... --extra-vars=@path/to/vars_file.yml
+                --extra-vars=key1=value1 key2=value2
+                --extra-vars='{"key3": "value3"}'...
         """
         for i, arg in enumerate(self.args):
             if '--extra_vars' in arg:
                 var_list_str = arg.split("--extra_vars=")[1]
-                var_list = ast.literal_eval(var_list_str)
-                var_list = [n.strip() for n in var_list]
+                var_list_str = arg.split("--extra_vars=")[1]
+                var_list = []
+                for n in ast.literal_eval(var_list_str):
+                    if type(n) in six.string_types:
+                        if n.strip().startswith("@"):
+                            var_list.append(('file', n.strip()))
+                        else:
+                            var_list.append(('kwarg', n.strip()))
+                    elif isinstance(n, dict):
+                        var_list.append(('json', n))
 
-                # Separate @file vars from kwarg vars
-                file_vars = list()
-                kwarg_vars = list()
-                for v in var_list:
-                    if "@" in v:
-                        file_vars.append(v)
-                    else:
-                        kwarg_vars.append(v)
+                last = ''
+                for t, v in var_list:
+                    # Add --extra-vars for each file
+                    if t == 'file':
+                        self.args.append("--extra-vars={0}".format(v))
 
-                # Add --extra-vars for each file
-                for v in file_vars:
-                    self.args.append("--extra-vars={0}".format(v))
+                    # Add --extra-vars for each json object
+                    elif t == 'json':
+                        self.args.append("--extra-vars='{0}'".format(json.dumps(v)))
 
-                # Combine kwarg vars into a single space-separated --extra-vars kwarg
-                if kwarg_vars:
-                    kv_param = "--extra-vars={0}".format(" ".join([v for v in kwarg_vars]))
-                    self.args.append(kv_param)
+                    # Combine contiguous kwarg vars into a single space-separated --extra-vars kwarg
+                    elif t == 'kwarg' and last != t:
+                        kv_param = "--extra-vars={0}".format(v)
+                    elif t == 'kwarg':  # last == t
+                        kv_param += " {0}".format(v)
+
+                    if last == 'kwarg' and t != last:
+                        self.args.append(kv_param)
+                        kv_param = ""
+
+                    last = t
 
                 del self.args[i]  # Delete the original arg since we split it into separate ones
                 break

--- a/actions/playbook.yaml
+++ b/actions/playbook.yaml
@@ -53,7 +53,7 @@ parameters:
     description: "when changing (small) files and templates, show the differences in those files; works great with --check [-D]"
     type: boolean
   extra_vars:
-    description: "List of additional variables to pass to ansible. Each variable is represented as \"key=value\" or \"@path/to/file.yaml|json\" [-e]."
+    description: "List of additional variables to pass to ansible. Each variable is represented as \"key=value\" or \"@path/to/file.yaml|json\" or use a yaml dict (\"key: [1, 2, 3]\") to send JSON. [-e]"
     type: array
   flush_cache:
     description: "Clear the fact cache"

--- a/actions/playbook.yaml
+++ b/actions/playbook.yaml
@@ -53,7 +53,7 @@ parameters:
     description: "when changing (small) files and templates, show the differences in those files; works great with --check [-D]"
     type: boolean
   extra_vars:
-    description: "List of additional variables to pass to ansible. Each variable is represented as \"key=value\" or \"@path/to/file.yaml|json\" or use a yaml dict (\"key: [1, 2, 3]\") to send JSON. [-e]"
+    description: 'List of additional variables to pass to ansible. Each variable is represented as "key=value" or "@path/to/file.yaml|json" or use a yaml dict ("key: [1, 2, 3]") to send JSON. [-e]'
     type: array
   flush_cache:
     description: "Clear the fact cache"

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - ansible
   - cfg management
   - configuration management
-version : 0.4.0
+version : 0.5.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/tests/fixtures/extra_vars.yaml
+++ b/tests/fixtures/extra_vars.yaml
@@ -1,0 +1,35 @@
+-
+  name: key_value
+  test:
+    - 'key1=value1'
+    - 'key2=value2'
+  expected:
+    - 'key1=value1 key2=value2'
+-
+  name: at_file
+  test:
+    - '@path/to/vars.yaml'
+    - '@path/to/vars.json'
+  expected:
+    - '@path/to/vars.yaml'
+    - '@path/to/vars.json'
+-
+  name: key_value_and_at_file
+  test:
+    - '@path/to/vars.yaml'
+    - 'key1=value1'
+    - '@path/to/vars.json'
+    - 'key2=value2'
+    - 'key3=value3'
+  # before ordering
+#  expected:
+#    - '@path/to/vars.yaml'
+#    - '@path/to/vars.json'
+#    - 'key1=value1 key2=value2 key3=value3'
+  # after ordering
+  expected:
+    - '@path/to/vars.yaml'
+    - 'key1=value1'
+    - '@path/to/vars.json'
+    - 'key2=value2 key3=value3'
+

--- a/tests/fixtures/extra_vars_complex.yaml
+++ b/tests/fixtures/extra_vars_complex.yaml
@@ -1,0 +1,28 @@
+-
+  name: arbitrarily_complex
+  test:
+    - 'key1=value1'
+    - 'key2=value2'
+    - '@/path/to/file.yml'
+    -
+      key3: 'value3'
+      key4: [ 'value4a', 'value4b' ]
+      key5:
+        - 'value5a'
+        - { value5bkey: 'value5bvalue', value5bkey2: [1,2,3] }
+      key6:
+        key7: 'value7'
+    - 'key8=value8'
+  expected:
+    - 'key1=value1 key2=value2'
+    - '@/path/to/file.yml'
+    -
+      key3: 'value3'
+      key4: [ 'value4a', 'value4b' ]
+      key5:
+        - 'value5a'
+        - { value5bkey: 'value5bvalue', value5bkey2: [1,2,3] }
+      key6:
+        key7: 'value7'
+    - 'key8=value8'
+

--- a/tests/fixtures/extra_vars_json.yaml
+++ b/tests/fixtures/extra_vars_json.yaml
@@ -1,0 +1,62 @@
+---
+-
+  name: dict
+  test:
+    -
+      key1: 'value1'
+      key2: 'value2'
+-
+  name: dict_with_list
+  test:
+    -
+      key1: ['value1', 'value2', 'value3']
+      key2:
+        - 'value4'
+        - 'value5'
+        - 'value6'
+-
+  name: dict_dict
+  test:
+    -
+      key1: {key1_1: 1, key1_2: 2}
+      key2:
+        key2_1: 1
+        key2_2: 1
+-
+  name: dict_multi
+  test:
+    -
+      key1: 'value1'
+      key2: 'value2'
+    -
+      key3: 'value3'
+      key4: 'value4'
+-
+  name: dict_with_list_multi
+  test:
+    -
+      key1: ['value1', 'value2', 'value3']
+      key2:
+        - 'value4'
+        - 'value5'
+        - 'value6'
+    -
+      key3: [1, 2, 3]
+      key4:
+        - 4
+        - 5
+        - 6
+-
+  name: dict_dict_multi
+  test:
+    -
+      key1: {key1_1: 1, key1_2: 2}
+      key2:
+        key2_1: 1
+        key2_2: 2
+    -
+      key3: {key3_1: 1, key3_2: 2}
+      key4:
+        key4_1: 1
+        key4_2: 2
+

--- a/tests/test_actions_lib_ansiblebaserunner.py
+++ b/tests/test_actions_lib_ansiblebaserunner.py
@@ -1,0 +1,123 @@
+from __future__ import print_function
+
+import json
+
+import six
+import yaml
+import shlex
+
+from st2common.models.system.action import ShellScriptAction
+from st2tests.pack_resource import BasePackResourceTestCase
+
+from lib.ansible_base import AnsibleBaseRunner
+
+
+class TestActionsLibAnsibleBaseRunner(BasePackResourceTestCase):
+
+    # from the ActiveDirectory test of a python action
+    def load_yaml(self, filename):
+        return yaml.safe_load(self.get_fixture_content(filename))
+
+    def setUp(self):
+        super(TestActionsLibAnsibleBaseRunner, self).setUp()
+
+    def test_init(self):
+        args = ['ansible_base.py', '--arg1', '--arg2', 'value2', '--arg3=value3']
+        ansible_base_runner = AnsibleBaseRunner(args)
+        self.assertEqual(ansible_base_runner.args, args[1:])
+
+    # AnsibleBaseRunner._parse_extra_vars()
+
+    @staticmethod
+    def generate_arg(st2_arg, value):
+        dummy_action = ShellScriptAction('', '', '')
+
+        # noinspection PyProtectedMember
+        arg = dummy_action._get_script_arguments(named_args={st2_arg: value})
+        arg = ' '.join(shlex.split(arg))
+
+        return arg
+
+    def check_arg_parse(self, arg_name, test_case, expected_ansible_args):
+        args = ['ansible_base.py', self.generate_arg(arg_name, test_case)]
+        ansible_base_runner = AnsibleBaseRunner(args)
+        self.assertItemsEqual(expected_ansible_args, ansible_base_runner.args)
+
+    def test_parse_extra_vars_key_value(self):
+        arg = '--extra_vars'
+        test = ['key1=value1', 'key2=value2']
+        expected = ['--extra-vars=' + ' '.join(test)]
+
+        self.check_arg_parse(arg, test, expected)
+
+    def test_parse_extra_vars_at_file(self):
+        arg = '--extra_vars'
+        test = ['@/path/to/vars_file.yaml', '@/other/path/vars_file.json']
+        expected = ['--extra-vars=' + case for case in test]
+
+        self.check_arg_parse(arg, test, expected)
+
+    def test_parse_extra_vars_at_file_and_key_value(self):
+        arg = '--extra_vars'
+        test = ['@/path/to/vars_file.yaml', 'key1=value1']
+        expected = ['--extra-vars=' + case for case in test]
+
+        self.check_arg_parse(arg, test, expected)
+
+    def extra_vars_yaml_fixture(self, test_name):
+        arg = '--extra_vars'
+        test_yaml = self.load_yaml('extra_vars.yaml')
+        test = next(t for t in test_yaml if t['name'] == test_name)
+        case = test['test']
+        expected = ['--extra-vars={}'.format(e) for e in test['expected']]
+        self.check_arg_parse(arg, case, expected)
+
+    def test_parse_extra_vars_yaml_key_value(self):
+        self.extra_vars_yaml_fixture('key_value')
+
+    def test_parse_extra_vars_yaml_at_file(self):
+        self.extra_vars_yaml_fixture('at_file')
+
+    def test_parse_extra_vars_yaml_key_value_and_at_file(self):
+        self.extra_vars_yaml_fixture('key_value_and_at_file')
+
+    def extra_vars_json_yaml_fixture(self, test_name):
+        arg = '--extra_vars'
+        test_yaml = self.load_yaml('extra_vars_json.yaml')
+        test = next(t for t in test_yaml if t['name'] == test_name)
+        case = test['test']
+        expected = ['--extra-vars=\'{}\''.format(json.dumps(e)) for e in case]
+        self.check_arg_parse(arg, case, expected)
+
+    def test_parse_extra_vars_json_yaml_dict(self):
+        self.extra_vars_json_yaml_fixture('dict')
+
+    def test_parse_extra_vars_json_yaml_dict_with_list(self):
+        self.extra_vars_json_yaml_fixture('dict_with_list')
+
+    def test_parse_extra_vars_json_yaml_dict_dict(self):
+        self.extra_vars_json_yaml_fixture('dict_dict')
+
+    def test_parse_extra_vars_json_yaml_dict_multi(self):
+        self.extra_vars_json_yaml_fixture('dict_multi')
+
+    def test_parse_extra_vars_json_yaml_dict_with_list_multi(self):
+        self.extra_vars_json_yaml_fixture('dict_with_list_multi')
+
+    def test_parse_extra_vars_json_yaml_dict_dict_multi(self):
+        self.extra_vars_json_yaml_fixture('dict_dict_multi')
+
+    def extra_vars_complex_yaml_fixture(self, test_name):
+        arg = '--extra_vars'
+        test_yaml = self.load_yaml('extra_vars_complex.yaml')
+        test = next(t for t in test_yaml if t['name'] == test_name)
+        case = test['test']
+        # this does not preserve the order exactly, but it shows that elements are correctly parsed
+        expected = ['--extra-vars={}'.format(e)
+                    for e in test['expected'] if isinstance(e, six.string_types)]
+        expected.extend(['--extra-vars=\'{}\''.format(json.dumps(e))
+                         for e in test['expected'] if isinstance(e, dict)])
+        self.check_arg_parse(arg, case, expected)
+
+    def test_parse_extra_vars_complex_yaml_arbitrarily_complex(self):
+        self.extra_vars_complex_yaml_fixture('arbitrarily_complex')


### PR DESCRIPTION
The docs[1] say that ansible supports json/yaml in extra_vars. Fixes #6. This adds support for sending arbitrarily complex extra_vars (such as when specifying parameters in a workflow) as json to ansible.

This also changes the concatenation of key=value pairs so that only contiguous key=value pairs are merged into the same extra-vars arg. That way, order is preserved in the rare case where someone overrides a variable in a subsequent extra_vars entry.

[1] http://docs.ansible.com/ansible/playbooks_variables.html#passing-variables-on-the-command-line