### PR TITLE
Added build status badge to the top of the README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://circleci.com/gh/StackStorm-Exchange/stackstorm-ansible.svg?style=shield)](https://circleci.com/gh/StackStorm-Exchange/stackstorm-ansible)
+
 # <img src="http://www.ansible.com/favicon.ico" width="32px" valign="-3px"/> Ansible Integration Pack
 This pack provides [Ansible](http://www.ansible.com/) integration to perform remote operations on both local and remote machines.
 After [pack installation](http://docs.stackstorm.com/packs.html#getting-a-pack) all ansible executable files are available in pack virtualenv and ready to use.


### PR DESCRIPTION
Added the CircleCI build status badge to the top of the README.md file.

You can view the badge here: https://github.com/nmaludy/stackstorm-ansible/tree/feature/readme-build-status-badge

