### PR TITLE
Added windows host support

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.2
+
+* Added pywinrm to requirements so connection to windows hosts is possible.
+  Contributed by Nick Maludy (Encore Technologies)
+
 ## v0.5.0
 
 * Added ability to use yaml structures to pass arbitrarily complex values through extra_vars. key=value and @file syntax is still supported. Example usage:

--- a/README.md
+++ b/README.md
@@ -99,6 +99,39 @@ There is, however, a bug that breaks the JSON when the playbook execution fails 
 }
 ```
 
+##### Windows Hosts
+
+Connecting to windows is possibe as of version `v0.5.2` of this pack.
+This is accomplished using ansible's [builtin windows support](http://docs.ansible.com/ansible/latest/intro_windows.html).
+
+Prior to executing a playbook on a Windows host, the host must be configured to
+accept WinRM connections. To accomplish this, execute the ansible [setup PowerShell script](https://github.com/ansible/ansible/blob/devel/examples/scripts/ConfigureRemotingForAnsible.ps1)
+on every Windows host you connect to. We recommend performing this on your
+Windows VM templates.
+
+The following `extra_vars` must be passed in when executing a playbook on a Windows host:
+
+* `ansible_user` : User to connect as (prefer user@domain.tld over domain\user)
+* `ansible_password` : Password to use when connecting
+* `ansible_connection` : Connection method to use (`winrm` for windows)
+* `ansible_port` : Port to use for the connection (`5986` for WinRM)
+* `ansible_winrm_transport` : WinRM transport to use for the connection (suggested: `ntlm` or `credssp`, for more information consult the [pywinrm documentation](https://github.com/diyan/pywinrm/).
+* `ansible_winrm_server_cert_validation` : Should the SSL cert be validated. (suggested: `ignore`)
+
+
+Connecting via NTLM using a `user@domain.tld` style login:
+
+``` sh
+st2 run ansible.playbook playbook=/etc/ansible/playbooks/windows_playbook.yaml inventory_file="winvm01.domain.tld," extra_vars='["ansible_user=user@domain.tld","ansible_password=xxx","ansible_port=5986","ansible_connection=winrm","ansible_winrm_server_cert_validation=ignore","ansible_winrm_transport=ntlm"]'
+```
+
+Connecting via CredSSP using a `DOMAIN\user` style login (note the extra `\`):
+
+``` sh
+st2 run ansible.playbook playbook=/etc/ansible/playbooks/windows_playbook.yaml inventory_file="winvm01.domain.tld," extra_vars='["ansible_user=DOMAIN\\\\user","ansible_password=xxx","ansible_port=5986","ansible_connection=winrm","ansible_winrm_server_cert_validation=ignore","ansible_winrm_transport=credssp"]'
+```
+
+
 #### `ansible.vault` examples
 ```sh
 # encrypt /tmp/nginx.yml playbook with password containing in vault.txt

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - ansible
   - cfg management
   - configuration management
-version : 0.5.1
+version : 0.5.2
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 ansible>=1.9
+pywinrm[credssp,kerberos]>=0.2.2


### PR DESCRIPTION
Previously the Ansible pack did not install the necessary requirements to support running playbooks on Windows hosts without modifying the pack's virtualenv manually after install.

This change adds the `pywinrm` module as a dependency along with the optional `credssp` and `kerberos` components as detailed in the [ansible windows documentation](http://docs.ansible.com/ansible/latest/intro_windows.html).

I've also updated the README to include a few examples of running playbooks against windows hosts.