### PR TITLE
Fix for #19 to fix JSON values in --extra-vars

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## v0.5.3
+
+* Fixed a bug where JSON data was being passed incorrectly to `--extra-vars`. #19
+  Contributed by Nick Maludy (Encore Technologies)
+
 ## v0.5.2
 
 * Added pywinrm to requirements so connection to windows hosts is possible.

--- a/actions/lib/ansible_base.py
+++ b/actions/lib/ansible_base.py
@@ -64,7 +64,7 @@ class AnsibleBaseRunner(object):
 
                     # Add --extra-vars for each json object
                     elif t == 'json':
-                        self.args.append("--extra-vars='{0}'".format(json.dumps(v)))
+                        self.args.append("--extra-vars={0}".format(json.dumps(v)))
 
                     # Combine contiguous kwarg vars into a single space-separated --extra-vars kwarg
                     elif t == 'kwarg' and last != t:

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - ansible
   - cfg management
   - configuration management
-version : 0.5.2
+version : 0.5.3
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/tests/test_actions_lib_ansiblebaserunner.py
+++ b/tests/test_actions_lib_ansiblebaserunner.py
@@ -86,7 +86,7 @@ class TestActionsLibAnsibleBaseRunner(BasePackResourceTestCase):
         test_yaml = self.load_yaml('extra_vars_json.yaml')
         test = next(t for t in test_yaml if t['name'] == test_name)
         case = test['test']
-        expected = ['--extra-vars=\'{}\''.format(json.dumps(e)) for e in case]
+        expected = ['--extra-vars={}'.format(json.dumps(e)) for e in case]
         self.check_arg_parse(arg, case, expected)
 
     def test_parse_extra_vars_json_yaml_dict(self):
@@ -115,7 +115,7 @@ class TestActionsLibAnsibleBaseRunner(BasePackResourceTestCase):
         # this does not preserve the order exactly, but it shows that elements are correctly parsed
         expected = ['--extra-vars={}'.format(e)
                     for e in test['expected'] if isinstance(e, six.string_types)]
-        expected.extend(['--extra-vars=\'{}\''.format(json.dumps(e))
+        expected.extend(['--extra-vars={}'.format(json.dumps(e))
                          for e in test['expected'] if isinstance(e, dict)])
         self.check_arg_parse(arg, case, expected)
 


### PR DESCRIPTION
Fixes #19 

This is a fix for #19 where handling of JSON values in `--extra-vars` was not working properly for me.

Please give @cognifloyd some time to review the issue before merging.