### PR TITLE
Add boto dependency to be able to use EC2 module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 ansible>=1.9
 pywinrm[credssp,kerberos]>=0.2.2
+boto>=2.48


### PR DESCRIPTION
Hope that the pinning looks right, that version works for me. Thanks to @reisingerf and @LindsayHill.