### PR TITLE
Set default CWD to current pack path (relative playbooks)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.4
+* Set default `CWD` working dir to current pack path,
+  allowing easy use relative playbooks that are shipped with pack (#9)
+
 ## v0.5.3
 
 * Fixed a bug where JSON data was being passed incorrectly to `--extra-vars`. #19

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## v0.5.4
-* Set default `CWD` working dir to current pack path,
-  allowing easy use relative playbooks that are shipped with pack (#9)
+* Set default `CWD` working dir to current pack/workflow path,
+  allowing using relative path to playbooks shipped with custom pack (#9)
 
 ## v0.5.3
 

--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ custom.workflow:
     a:
       action: ansible.playbook
       input:
+        # 'ansible_play.yml' is part of the 'custom' pack
         playbook: "ansible_play.yml"
         inventory_file: "localhost,"
 ```

--- a/actions/command.yaml
+++ b/actions/command.yaml
@@ -15,8 +15,9 @@ parameters:
     type: boolean
     default: true
   cwd:
-    description: "Working directory where the command will be executed in"
+    description: "Working directory where the command will be executed in (current pack dir)"
     type: string
+    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds"
     type: integer

--- a/actions/command.yaml
+++ b/actions/command.yaml
@@ -15,9 +15,9 @@ parameters:
     type: boolean
     default: true
   cwd:
-    description: "Working directory where the command will be executed in (current pack dir)"
+    description: "Working directory where the command will be executed in (default: current pack/workflow dir)"
     type: string
-    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
+    default: "/opt/stackstorm/packs/{% if action_context.parent is defined %}{{ action_context.parent.pack }}{% else %}{{ action_context.pack }}{% endif %}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds"
     type: integer

--- a/actions/command_local.yaml
+++ b/actions/command_local.yaml
@@ -15,8 +15,9 @@ parameters:
     type: boolean
     default: true
   cwd:
-    description: "Working directory where the command will be executed in"
+    description: "Working directory where the command will be executed in (current pack dir)"
     type: string
+    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds"
     type: integer

--- a/actions/command_local.yaml
+++ b/actions/command_local.yaml
@@ -15,9 +15,9 @@ parameters:
     type: boolean
     default: true
   cwd:
-    description: "Working directory where the command will be executed in (current pack dir)"
+    description: "Working directory where the command will be executed in (default: current pack/workflow dir)"
     type: string
-    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
+    default: "/opt/stackstorm/packs/{% if action_context.parent is defined %}{{ action_context.parent.pack }}{% else %}{{ action_context.pack }}{% endif %}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds"
     type: integer

--- a/actions/galaxy.install.yaml
+++ b/actions/galaxy.install.yaml
@@ -14,13 +14,14 @@ parameters:
     description: "Lock sudo, the behavior is controlled by ansible 'become_' options"
     type: boolean
     default: true
+  cwd:
+    description: "Working directory where the command will be executed in (current pack dir)"
+    type: string
+    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds"
     type: integer
     default: 300
-  cwd:
-    description: "Working directory where the command will be executed in"
-    type: string
   action:
     description: "Action to use"
     type: string

--- a/actions/galaxy.install.yaml
+++ b/actions/galaxy.install.yaml
@@ -15,9 +15,9 @@ parameters:
     type: boolean
     default: true
   cwd:
-    description: "Working directory where the command will be executed in (current pack dir)"
+    description: "Working directory where the command will be executed in (default: current pack/workflow dir)"
     type: string
-    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
+    default: "/opt/stackstorm/packs/{% if action_context.parent is defined %}{{ action_context.parent.pack }}{% else %}{{ action_context.pack }}{% endif %}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds"
     type: integer

--- a/actions/galaxy.list.yaml
+++ b/actions/galaxy.list.yaml
@@ -15,9 +15,9 @@ parameters:
     type: boolean
     default: true
   cwd:
-    description: "Working directory where the command will be executed in (current pack dir)"
+    description: "Working directory where the command will be executed in (default: current pack/workflow dir)"
     type: string
-    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
+    default: "/opt/stackstorm/packs/{% if action_context.parent is defined %}{{ action_context.parent.pack }}{% else %}{{ action_context.pack }}{% endif %}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. Lock as uneeded"
     type: integer

--- a/actions/galaxy.list.yaml
+++ b/actions/galaxy.list.yaml
@@ -14,14 +14,15 @@ parameters:
     description: "Lock sudo, the behavior is controlled by ansible 'become_' options"
     type: boolean
     default: true
+  cwd:
+    description: "Working directory where the command will be executed in (current pack dir)"
+    type: string
+    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. Lock as uneeded"
     type: integer
     default: 60
     immutable: true
-  cwd:
-    description: "Working directory where the command will be executed in"
-    type: string
   action:
     description: "Action to use"
     type: string

--- a/actions/galaxy.remove.yaml
+++ b/actions/galaxy.remove.yaml
@@ -15,9 +15,9 @@ parameters:
     type: boolean
     default: true
   cwd:
-    description: "Working directory where the command will be executed in (current pack dir)"
+    description: "Working directory where the command will be executed in (default: current pack/workflow dir)"
     type: string
-    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
+    default: "/opt/stackstorm/packs/{% if action_context.parent is defined %}{{ action_context.parent.pack }}{% else %}{{ action_context.pack }}{% endif %}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. Lock as uneeded"
     type: integer

--- a/actions/galaxy.remove.yaml
+++ b/actions/galaxy.remove.yaml
@@ -14,14 +14,15 @@ parameters:
     description: "Lock sudo, the behavior is controlled by ansible 'become_' options"
     type: boolean
     default: true
+  cwd:
+    description: "Working directory where the command will be executed in (current pack dir)"
+    type: string
+    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. Lock as uneeded"
     type: integer
     default: 120
     immutable: true
-  cwd:
-    description: "Working directory where the command will be executed in"
-    type: string
   action:
     description: "Action to use"
     type: string

--- a/actions/playbook.yaml
+++ b/actions/playbook.yaml
@@ -15,8 +15,9 @@ parameters:
     type: boolean
     default: true
   cwd:
-    description: "Working directory where the command will be executed in"
+    description: "Working directory where the command will be executed in (current pack dir)"
     type: string
+    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds"
     type: integer

--- a/actions/playbook.yaml
+++ b/actions/playbook.yaml
@@ -15,9 +15,9 @@ parameters:
     type: boolean
     default: true
   cwd:
-    description: "Working directory where the command will be executed in (current pack dir)"
+    description: "Working directory where the command will be executed in (default: current pack/workflow dir)"
     type: string
-    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
+    default: "/opt/stackstorm/packs/{% if action_context.parent is defined %}{{ action_context.parent.pack }}{% else %}{{ action_context.pack }}{% endif %}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds"
     type: integer

--- a/actions/vault.decrypt.yaml
+++ b/actions/vault.decrypt.yaml
@@ -14,6 +14,10 @@ parameters:
     description: "Lock sudo, the behavior is controlled by ansible 'become_' options"
     type: boolean
     default: true
+  cwd:
+    description: "Working directory where the command will be executed in (current pack dir)"
+    type: string
+    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. Lock as uneeded"
     type: integer
@@ -34,9 +38,6 @@ parameters:
     description: "Vault file with password"
     type: string
     required: true
-  cwd:
-    description: "Working directory where the command will be executed in"
-    type: string
   debug:
     description: "Enable debug mode"
     type: boolean

--- a/actions/vault.decrypt.yaml
+++ b/actions/vault.decrypt.yaml
@@ -15,9 +15,9 @@ parameters:
     type: boolean
     default: true
   cwd:
-    description: "Working directory where the command will be executed in (current pack dir)"
+    description: "Working directory where the command will be executed in (default: current pack/workflow dir)"
     type: string
-    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
+    default: "/opt/stackstorm/packs/{% if action_context.parent %}{{ action_context.parent.pack }}{% else %}{{ action_context.pack }}{% endif %}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. Lock as uneeded"
     type: integer

--- a/actions/vault.encrypt.yaml
+++ b/actions/vault.encrypt.yaml
@@ -14,6 +14,10 @@ parameters:
     description: "Lock sudo, the behavior is controlled by ansible 'become_' options"
     type: boolean
     default: true
+  cwd:
+    description: "Working directory where the command will be executed in (current pack dir)"
+    type: string
+    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. Lock as uneeded"
     type: integer
@@ -34,9 +38,6 @@ parameters:
     description: "Vault file with password"
     type: string
     required: true
-  cwd:
-    description: "Working directory where the command will be executed in"
-    type: string
   debug:
     description: "Enable debug mode"
     type: boolean

--- a/actions/vault.encrypt.yaml
+++ b/actions/vault.encrypt.yaml
@@ -15,9 +15,9 @@ parameters:
     type: boolean
     default: true
   cwd:
-    description: "Working directory where the command will be executed in (current pack dir)"
+    description: "Working directory where the command will be executed in (default: current pack/workflow dir)"
     type: string
-    default: "/opt/stackstorm/packs/{{ action_context.pack }}"
+    default: "/opt/stackstorm/packs/{% if action_context.parent %}{{ action_context.parent.pack }}{% else %}{{ action_context.pack }}{% endif %}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. Lock as uneeded"
     type: integer

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - ansible
   - cfg management
   - configuration management
-version : 0.5.3
+version : 0.5.4
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Closes #9.

Make the pack path as a default current working dir.
The behavior makes sense when invoking ansible pack actions from the custom workflow, allowing to use relative path to Ansible playbooks shipped with that pack.

cc @cognifloyd

The example is in README.