### PR TITLE
Fix Jinja rendering for Ansible vault actions

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.5.5
+
+* Fix Jinja rendering issue for Ansible vault actions (#28)
+
 ## v0.5.4
 * Set default `CWD` working dir to current pack/workflow path,
   allowing using relative path to playbooks shipped with custom pack (#9)

--- a/actions/vault.decrypt.yaml
+++ b/actions/vault.decrypt.yaml
@@ -17,7 +17,7 @@ parameters:
   cwd:
     description: "Working directory where the command will be executed in (default: current pack/workflow dir)"
     type: string
-    default: "/opt/stackstorm/packs/{% if action_context.parent %}{{ action_context.parent.pack }}{% else %}{{ action_context.pack }}{% endif %}"
+    default: "/opt/stackstorm/packs/{% if action_context.parent is defined %}{{ action_context.parent.pack }}{% else %}{{ action_context.pack }}{% endif %}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. Lock as uneeded"
     type: integer

--- a/actions/vault.encrypt.yaml
+++ b/actions/vault.encrypt.yaml
@@ -17,7 +17,7 @@ parameters:
   cwd:
     description: "Working directory where the command will be executed in (default: current pack/workflow dir)"
     type: string
-    default: "/opt/stackstorm/packs/{% if action_context.parent %}{{ action_context.parent.pack }}{% else %}{{ action_context.pack }}{% endif %}"
+    default: "/opt/stackstorm/packs/{% if action_context.parent is defined %}{{ action_context.parent.pack }}{% else %}{{ action_context.pack }}{% endif %}"
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. Lock as uneeded"
     type: integer

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - ansible
   - cfg management
   - configuration management
-version : 0.5.4
+version : 0.5.5
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
This PR fixes the following error:
```
ERROR: 400 Client Error: Bad Request
MESSAGE: Failed to render parameter "cwd": 'mongoengine.base.datastructures.BaseDict object' has no attribute 'parent' for url: http://127.0.0.1:9101/v1/executions
```
while trying to run Ansible Vault action via this pack.