### PR TITLE
Fix Ansible pack shebang to utilize st2 python virtualenv

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.5.6
+*  Fix Ansible pack shebang to utilize st2 python virtualenv (#33)
+
 ## v0.5.5
 
 * Fix Jinja rendering issue for Ansible vault actions (#28)

--- a/actions/ansible.py
+++ b/actions/ansible.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/stackstorm/st2/bin/python
 
 import sys
 from lib.ansible_base import AnsibleBaseRunner

--- a/actions/ansible_galaxy.py
+++ b/actions/ansible_galaxy.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/stackstorm/st2/bin/python
 
 import sys
 from lib.ansible_base import AnsibleBaseRunner

--- a/actions/ansible_playbook.py
+++ b/actions/ansible_playbook.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/stackstorm/st2/bin/python
 
 import sys
 from lib.ansible_base import AnsibleBaseRunner

--- a/actions/ansible_vault.py
+++ b/actions/ansible_vault.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/opt/stackstorm/st2/bin/python
 
 import sys
 from lib.ansible_base import AnsibleBaseRunner

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - ansible
   - cfg management
   - configuration management
-version : 0.5.5
+version : 0.5.6
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Closes #31 

Some systems are missing 'six' python module, making ansible pack unable to run.
Use st2 python virtualenv instead, which has everything we need.


----

Alternative approach to solve this is to migrate to `python-script` runner, but we'll lose the flexibility of `cwd` and `sudo` params from the `local-shell-script` used in some cases.