### PR TITLE
Fix pack compatibility under python 3 when implicit relative import was used

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v0.5.9
+* Fix pack compatibility under python 3 when unsupported implicit relative import was used (#41)
+
 ## v0.5.8
 *  Minor linting fix
 

--- a/actions/lib/ansible_base.py
+++ b/actions/lib/ansible_base.py
@@ -1,10 +1,11 @@
 import os
 import sys
 import subprocess
-import shell
 import ast
 import json
 import six
+
+from . import shell
 
 __all__ = [
     'AnsibleBaseRunner'

--- a/pack.yaml
+++ b/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - ansible
   - cfg management
   - configuration management
-version : 0.5.8
+version : 0.5.9
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Implicit relative imports used to work in python 2, but were deprecated in python 3:
See https://docs.python.org/3.0/whatsnew/3.0.html#removed-syntax

Fix pack imports to work under py3

Fixes #40